### PR TITLE
fix: Correctly export `dav` from the package

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -2,8 +2,7 @@
  * vim: expandtab shiftwidth=4 softtabstop=4
  */
 
-/* global dav */
-var dav = dav || {}
+const dav = {}
 
 dav._XML_CHAR_MAP = {
     '<': '&lt;',
@@ -482,6 +481,7 @@ dav.Client.prototype = {
 
 };
 
-if (typeof module !== 'undefined' && typeof module.exports !== 'undefined') {
-    module.exports.Client = dav.Client;
+module.exports = {
+    dav,
+    Client: dav.Client,
 }


### PR DESCRIPTION
Fix the package instead of hacky patching in server webpack config.
This is required when we want to bundle with Vite.